### PR TITLE
Revert "Merged SCSS and SASS loaders"

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -13,7 +13,7 @@ module.exports = {
   webpackFinal: async (config, { configType }) => {
     // Use Sass loader for vuetify components
     config.module.rules.push({
-      test: /\.s[ac]ss$/i,
+      test: /\.sass$/,
       use: [
         'style-loader',
         'vue-style-loader',
@@ -24,6 +24,23 @@ module.exports = {
           options: {
             // This is the path to your variables
             additionalData: `@import '@/styles/variables.scss'`
+          },
+        },
+      ],
+      include: path.resolve(__dirname, '../'),
+    });
+    config.module.rules.push({
+      test: /\.scss$/,
+      use: [
+        'style-loader',
+        'vue-style-loader',
+        'css-loader',
+        {
+          loader: 'sass-loader',
+          // Requires sass-loader@^9.0.0
+          options: {
+            // This is the path to your variables
+            additionalData: `@import '@/styles/variables.scss';`
           },
         },
       ],


### PR DESCRIPTION
Reverts desiboli/storybook-vue-vuetify#1

@Dschungelabenteuer now I remember why I couldn't use this, I remember trying this before but ending up with this sass error:

`
ERROR in ./src/stories/VButton.vue?vue&type=style&index=0&id=268b50a3&lang=scss&scoped=true& (./node_modules/css-loader/dist/cjs.js!./node_modules/vue-loader/lib/loaders/stylePostLoader.js!./node_modules/sass-loader/dist/cjs.js??ref--13-3!./node_modules/vue-loader/lib??vue-loader-options!./src/stories/VButton.vue?vue&type=style&index=0&id=268b50a3&lang=scss&scoped=true&)
Module build failed (from ./node_modules/sass-loader/dist/cjs.js):
SassError: expected ";".
`

Did you manage to make it work locally with this change ?